### PR TITLE
Replace c++11 constexpr with c++98 external initialization

### DIFF
--- a/include/diffdrive_gazebo_plugin/gazebo_ros_diffdrive_uos.h
+++ b/include/diffdrive_gazebo_plugin/gazebo_ros_diffdrive_uos.h
@@ -25,7 +25,7 @@ public:
 
 private:
   static const size_t NUM_JOINTS = 6;
-  static constexpr double CMD_VEL_TIMEOUT = 0.6;
+  static const double CMD_VEL_TIMEOUT;
 
   void OnCmdVel(const geometry_msgs::TwistConstPtr &msg);
 

--- a/src/gazebo_ros_diffdrive_uos.cpp
+++ b/src/gazebo_ros_diffdrive_uos.cpp
@@ -14,6 +14,8 @@ enum
   LEFT = 1, RIGHT = 4
 };
 
+const double gazebo::GazeboRosDiffdrive::CMD_VEL_TIMEOUT = 0.6;
+
 GazeboRosDiffdrive::GazeboRosDiffdrive() :
   wheel_speed_right_(0.0),
   wheel_speed_left_(0.0)


### PR DESCRIPTION
This fixes the following compile error on Ubuntu 14.04 / Indigo:

```
include/diffdrive_gazebo_plugin/gazebo_ros_diffdrive_uos.h:28:10: error: 'constexpr' does not name a type
   static constexpr double CMD_VEL_TIMEOUT = 0.6;
```

The problem is that 66aab37 introduced this C++11 feature, but 9edd4c8
replaced `add_compile_options(-std=c++11)` with `GAZEBO_CXX_FLAGS`.
However, `GAZEBO_CXX_FLAGS` is empty on Indigo (it works on Jade).

Any of the following will fix this:
1. revert 66aab37
2. better: use the non-c++11 way of doing what 66aab37 does (external initialization, as pointed out in the commit message)
3. revert 9edd4c8
4. probably better: add both `-std=c++11` and `GAZEBO_CXX_FLAGS`, since we're using c++11 in 66aab37 independent of what Gazebo uses

This pull request implements (2). Any thoughts, @v4hn @jspricke?
